### PR TITLE
Support jdbc options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sweet-crud "0.1.12"
+(defproject sweet-crud "0.1.13"
   :description "Two complementary macros to create compojure.api.sweet CRUD routes, with (configurable) database calls."
   :url "https://github.com/Kah0ona/sweet-crud.git"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/sweet_crud/core.clj
+++ b/src/sweet_crud/core.clj
@@ -35,17 +35,21 @@
 
 (defn find-records-by-criteria
   "criteria should be a honeysql where clause."
-  [table where-clauses conn]
-  (let [base-query      (-> (select :*)
-                            (from (keyword table)))
-        formatted-query (-> (partial where base-query)
-                            (apply where-clauses)
-                            sql/format)]
-    (j/query conn formatted-query)))
+  ([table where-clauses conn]
+   (find-records-by-criteria table where-clauses conn {}))
+  ([table where-clauses conn opts]
+   (let [base-query      (-> (select :*)
+                             (from (keyword table)))
+         formatted-query (-> (partial where base-query)
+                             (apply where-clauses)
+                             sql/format)]
+     (j/query conn formatted-query opts))))
 
 (defn find-records
-  [table conn]
-  (j/query conn [(str "SELECT * FROM " table)]))
+  ([table conn]
+   (find-records table conn {}))
+  ([table conn opts]
+   (j/query conn [(str "SELECT * FROM " table)] opts)))
 
 (defn update-record-in-db!
   "Generic function that updates a record in specified table"


### PR DESCRIPTION
- [x] Pass on an optional opts map to clojure.java.jdbc/query
- [x] Check if there are more places where this should be supported (e.g. create, update, delete?)
- [x] Bump up project version

This is **not** needed for create/update et al, because `clojure.java.jdbc/as-sql-name` automatically selects the `name` of an input key(word). So when you update `:product/product_name`, `"product_name"` or `:product_name`, it should work regardless.